### PR TITLE
 feat: Add string interpolation to variables in manifest.yml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    table_saw (2.10.0)
+    table_saw (2.11.0)
       activerecord (>= 5.2)
       pg
       thor

--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ tables:
     query: "select * from books where author_id = %{author_id}"
 ```
 
+Additionally, you can now use the `%{variable}` substitution pattern in subsequent variables:
+```yaml
+variables:
+  author_id: '1,3,4',
+  book_ids: 'select * from books where author_id in (%{author_id})' 
+```
+
+Note that only previously assigned variables can be substituted into subsequent variables, attempting to access a variable before it is declared like this:
+```yaml
+variables:
+  author_id: '%{book_ids}',
+  book_ids: 'select * from books limit 10'  
+```
+will result in incorrectly assembled queries (i.e. passing %{book_ids} into the SQL query.)
+
 #### tables
 This is where you list the specific tables that you want to export. If you only specify the `table` without providing a 
 `query`, then the **entire** table will be exported. However, if you specify a `query`, then only rows matching that 

--- a/lib/table_saw/version.rb
+++ b/lib/table_saw/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module TableSaw
-  VERSION = '2.10.0'
+  VERSION = '2.11.0'
 end

--- a/spec/table_saw/manifest_spec.rb
+++ b/spec/table_saw/manifest_spec.rb
@@ -48,6 +48,35 @@ RSpec.describe TableSaw::Manifest do
     end
   end
 
+  describe '#variables with interpolation' do
+    let(:config) do
+      {
+        'variables' => {
+          'author_id' => author_id,
+          'illustrator_id' => '%{author_id}'
+        },
+        'tables' => [
+          { 'table' => 'authors' },
+          { 'table' => 'books', 'query' => 'select * from books where author_id = %{illustrator_id}' }
+        ]
+      }
+    end
+    let(:author_id) { 134 }
+
+    it 'interpolates previous variables into following variables' do
+      expect(manifest.variables[:illustrator_id]).to eq manifest.variables[:author_id]
+      expect(manifest.variables[:illustrator_id]).to_not eq '%{illustrator_id}'
+    end
+
+    context 'when attempting to interpolate another variable before it is declared' do
+      let(:author_id) { '%{illustrator_id}' }
+
+      it 'does not interpolate following variables into the initial variables' do
+        expect(manifest.variables[:author_id]).to be_nil
+      end
+    end
+  end
+
   describe '#tables' do
     it 'returns correct size' do
       expect(manifest.tables.size).to eq 2
@@ -60,6 +89,26 @@ RSpec.describe TableSaw::Manifest do
 
       it 'returns correct query' do
         expect(manifest.tables.values.map(&:query)).to eq([nil, 'select * from books where author_id = 134'])
+      end
+    end
+
+    context 'when the table query uses interpolated variables' do
+      let(:config) do
+        {
+          'variables' => {
+            'author_id' => '1,3,4',
+            'book_ids' => 'select * from books where author_id in (%{author_id})'
+          },
+          'tables' => [
+            { 'table' => 'authors' },
+            { 'table' => 'books', 'query' => 'select * from books where book_id in (%{book_ids})' }
+          ]
+        }
+      end
+
+      it 'returns the correct query' do
+        composed_query = 'select * from books where book_id in (select * from books where author_id in (1,3,4))'
+        expect(manifest.tables.values.map(&:query)).to eq([nil, composed_query])
       end
     end
   end


### PR DESCRIPTION
Similar to how table queries can be constructed using variable
stand-ins, to enhance understanding in a manifest.yml file we want to be
able to re use a variable inside the builder for another variable.
Example:

```yaml
variables:
  book_ids: '1,3,4,10'
  author_ids: 'select * from authors where book_id in (%{book_ids})'
```

Co-authored-by: Eric Wanchic <ewanchic@g2.com>
